### PR TITLE
fix(health-check): use redis password config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     command: mongod --setParameter notablescan=1
 
   redis:
+    command: redis-server --requirepass redispassword
     container_name: redis
     image: redis:5.0.9-alpine
     ports:

--- a/packages/health-check/.env
+++ b/packages/health-check/.env
@@ -1,2 +1,3 @@
 REDIS_URL=localhost
 REDIS_PORT=6379
+REDIS_PASSWORD='redispassword'

--- a/packages/health-check/src/health-check.module.ts
+++ b/packages/health-check/src/health-check.module.ts
@@ -12,6 +12,7 @@ import { MongoIndicator, RedisIndicator } from './indicator'
       useFactory: (configService: ConfigService) => ({
         host: configService.get('REDIS_URL'),
         port: configService.get('REDIS_PORT'),
+        password: configService.get('REDIS_PASSWORD'),
       }),
       inject: [ConfigService],
     }),


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/dJGYFScvBjfRabiH7m/giphy.gif)

### What?
Pass redis password

### Why?
Our staging/production redis instances uses passwords