### PR TITLE
refactor(pagination): use default values to pagination take

### DIFF
--- a/packages/pagination/src/pagination-args.ts
+++ b/packages/pagination/src/pagination-args.ts
@@ -1,6 +1,6 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql'
 import { Transform } from 'class-transformer'
-import { IsInt, Max, Min } from 'class-validator'
+import { IsInt, Min } from 'class-validator'
 import { Pagination } from './pagination'
 
 @ArgsType()
@@ -17,9 +17,12 @@ export class PaginationArgs {
 
   @Field(() => Int)
   @IsInt()
-  @Min(PaginationArgs.MIN_TAKE)
-  @Max(PaginationArgs.MAX_TAKE)
-  @Transform(value => value || PaginationArgs.MAX_TAKE)
+  @Transform(value => {
+    if (value < PaginationArgs.MIN_TAKE) return PaginationArgs.MIN_TAKE
+    if (value > PaginationArgs.MAX_TAKE) return PaginationArgs.MAX_TAKE
+
+    return PaginationArgs.MAX_TAKE
+  })
   take: number = PaginationArgs.MAX_TAKE
 
   get pagination(): Pagination {

--- a/packages/pagination/test/pagination-args.test.ts
+++ b/packages/pagination/test/pagination-args.test.ts
@@ -29,26 +29,14 @@ export class PaginationArgsTest {
   }
 
   @test()
-  async 'Take produces validation errors when greater than PaginationArgs.MAX_TAKE'() {
-    const pageArgs = plainToClass(PaginationArgs, { take: 10 ** 6 })
-    expect(pageArgs.take).toBeGreaterThan(PaginationArgs.MAX_TAKE)
-
-    const [error] = await validate(pageArgs)
-
-    expect(error.property).toBe('take')
-    expect(error.constraints.max).toEqual(
-      `take must not be greater than ${PaginationArgs.MAX_TAKE}`,
-    )
+  async 'Take the default maximum value when greater than PaginationArgs.MAX_TAKE'() {
+    const pageArgs = plainToClass(PaginationArgs, { take: 60 })
+    expect(pageArgs.take).toEqual(PaginationArgs.MAX_TAKE)
   }
 
   @test()
-  async 'Take produces validation errors when smaller than PaginationArgs.MIN_TAKE'() {
+  async 'Take the default minimum value when smaller than PaginationArgs.MIN_TAKE'() {
     const pageArgs = plainToClass(PaginationArgs, { take: -10 })
-    expect(pageArgs.take).toBeLessThan(PaginationArgs.MIN_TAKE)
-
-    const [error] = await validate(pageArgs)
-
-    expect(error.property).toBe('take')
-    expect(error.constraints.min).toEqual(`take must not be less than ${PaginationArgs.MIN_TAKE}`)
+    expect(pageArgs.take).toEqual(PaginationArgs.MIN_TAKE)
   }
 }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/pzryvxGeykOxeC0fWb/giphy.gif)

### What?

Use default values to pagination `take` when:
- The value is greater than **MAX_TAKE**;
- The value is smaller than **MIN_TAKE**.

### Why?

Because we think that throwing an error to the user is not a good experience.

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Paginação na listagem de conteúdos por pastas](https://app.asana.com/0/1188321867452078/1199168889568198/f)

