### PR TITLE
refactor(pagination): remove validations from args

### DIFF
--- a/packages/pagination/jest.config.js
+++ b/packages/pagination/jest.config.js
@@ -12,5 +12,5 @@ module.exports = {
   collectCoverage: true,
   forceExit: true,
   coverageReporters: ['lcovonly', 'text'],
-  collectCoverageFrom: ['src/**/{!(index|pagination-result|pagination.ts),}.ts'],
+  collectCoverageFrom: ['src/**/{!(index|pagination-result),}.ts'],
 }

--- a/packages/pagination/src/pagination-args.ts
+++ b/packages/pagination/src/pagination-args.ts
@@ -1,29 +1,18 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql'
-import { Transform } from 'class-transformer'
-import { IsInt, Min } from 'class-validator'
+import { IsInt, IsOptional } from 'class-validator'
 import { Pagination } from './pagination'
 
 @ArgsType()
 export class PaginationArgs {
-  public static readonly MIN_SKIP: number = 0
-  public static readonly MIN_TAKE: number = 1
-  public static readonly MAX_TAKE: number = 50
-
-  @Field(() => Int)
+  @Field(() => Int, { nullable: true })
+  @IsOptional()
   @IsInt()
-  @Min(PaginationArgs.MIN_SKIP)
-  @Transform(value => value || PaginationArgs.MIN_SKIP)
-  skip: number = PaginationArgs.MIN_SKIP
+  skip?: number
 
-  @Field(() => Int)
+  @Field(() => Int, { nullable: true })
+  @IsOptional()
   @IsInt()
-  @Transform(value => {
-    if (value < PaginationArgs.MIN_TAKE) return PaginationArgs.MIN_TAKE
-    if (value > PaginationArgs.MAX_TAKE) return PaginationArgs.MAX_TAKE
-
-    return PaginationArgs.MAX_TAKE
-  })
-  take: number = PaginationArgs.MAX_TAKE
+  take?: number
 
   get pagination(): Pagination {
     return new Pagination(this.skip, this.take)

--- a/packages/pagination/src/pagination.ts
+++ b/packages/pagination/src/pagination.ts
@@ -1,3 +1,25 @@
 export class Pagination {
-  constructor(readonly skip: number, readonly take: number) {}
+  static readonly MIN_SKIP: number = 0
+  static readonly MIN_TAKE: number = 1
+  static readonly MAX_TAKE: number = 50
+
+  private readonly _skip: number
+  private readonly _take: number
+
+  constructor(skip: number, take: number) {
+    this._skip = skip
+    this._take = take
+  }
+
+  get skip(): number {
+    return this._skip
+  }
+
+  get take(): number {
+    if (this._take === null || this._take === undefined) return Pagination.MAX_TAKE
+    if (this._take < Pagination.MIN_TAKE) return Pagination.MIN_TAKE
+    if (this._take > Pagination.MAX_TAKE) return Pagination.MAX_TAKE
+
+    return this._take
+  }
 }

--- a/packages/pagination/test/pagination-args.test.ts
+++ b/packages/pagination/test/pagination-args.test.ts
@@ -6,37 +6,22 @@ import { PaginationArgs } from '../src/pagination-args'
 @suite('[Pagination] Pagination Args')
 export class PaginationArgsTest {
   @test()
-  'Skip defaults to PaginationArgs.MIN_SKIP when not provided'() {
-    const pagination = plainToClass(PaginationArgs, {})
-    expect(pagination.skip).toEqual(PaginationArgs.MIN_SKIP)
-  }
+  async 'Given a not integer "skip" then throw error'() {
+    const paginationArgs = plainToClass(PaginationArgs, { skip: '10' })
 
-  @test()
-  async 'Skip produces validation errors when smaller than PaginationArgs.MIN_SKIP'() {
-    const pageArgs = plainToClass(PaginationArgs, { skip: -10 })
-    expect(pageArgs.skip).toBeLessThan(PaginationArgs.MIN_SKIP)
-
-    const [error] = await validate(pageArgs)
+    const [error] = await validate(paginationArgs)
 
     expect(error.property).toBe('skip')
-    expect(error.constraints.min).toEqual(`skip must not be less than ${PaginationArgs.MIN_SKIP}`)
+    expect(error.constraints.isInt).toEqual('skip must be an integer number')
   }
 
   @test()
-  'Take defaults to PaginationArgs.MAX_TAKE when not provided'() {
-    const pagination = plainToClass(PaginationArgs, {})
-    expect(pagination.take).toEqual(PaginationArgs.MAX_TAKE)
-  }
+  async 'Given a not integer "take" then throw error'() {
+    const paginationArgs = plainToClass(PaginationArgs, { take: '50' })
 
-  @test()
-  async 'Take the default maximum value when greater than PaginationArgs.MAX_TAKE'() {
-    const pageArgs = plainToClass(PaginationArgs, { take: 60 })
-    expect(pageArgs.take).toEqual(PaginationArgs.MAX_TAKE)
-  }
+    const [error] = await validate(paginationArgs)
 
-  @test()
-  async 'Take the default minimum value when smaller than PaginationArgs.MIN_TAKE'() {
-    const pageArgs = plainToClass(PaginationArgs, { take: -10 })
-    expect(pageArgs.take).toEqual(PaginationArgs.MIN_TAKE)
+    expect(error.property).toBe('take')
+    expect(error.constraints.isInt).toEqual('take must be an integer number')
   }
 }

--- a/packages/pagination/test/pagination.test.ts
+++ b/packages/pagination/test/pagination.test.ts
@@ -1,0 +1,29 @@
+import { suite, test } from '@testdeck/jest'
+import { Pagination } from '../src/pagination'
+
+@suite('[Pagination] Pagination Test')
+export class PaginationTest {
+  @test()
+  'Given "take" null then return the default maximum value'() {
+    const pagination = new Pagination(1, null)
+    expect(pagination.take).toEqual(Pagination.MAX_TAKE)
+  }
+
+  @test()
+  'Given "take" greater than MAX_TAKE then return the default maximum value'() {
+    const pagination1 = new Pagination(1, 60)
+    expect(pagination1.take).toEqual(Pagination.MAX_TAKE)
+  }
+
+  @test()
+  'Given "take" smaller than MIN_TAKE then return the default minimum value'() {
+    const pagination = new Pagination(1, 0)
+    expect(pagination.take).toEqual(Pagination.MIN_TAKE)
+  }
+
+  @test()
+  'Given a valid "take" then return it'() {
+    const pagination = new Pagination(1, 10)
+    expect(pagination.take).toEqual(10)
+  }
+}


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/12uXi1GXBibALC/giphy.gif)

### What?

- Remove `Min` and `Max` validations from **pagination-args**;
- Move the default values logic to the `pagination class`, because the `pagination args` represent only the **graphql** parameters.

### Why?

To keep the pagination rules in `pagination class`.

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Paginação na listagem de conteúdos por pastas](https://app.asana.com/0/1188321867452078/1199168889568198/f)
