### PR TITLE
refactor!: rename organization to environment

### DIFF
--- a/packages/keycloak/src/domain/user.domain.ts
+++ b/packages/keycloak/src/domain/user.domain.ts
@@ -16,6 +16,6 @@ export class User {
   @Expose({ name: 'preferred_username' })
   username: string
 
-  @Expose({ name: 'organization_id' })
-  organizationId: string
+  @Expose({ name: 'environment_id' })
+  environmentId: string
 }

--- a/packages/keycloak/test/service/find-user.service.test.ts
+++ b/packages/keycloak/test/service/find-user.service.test.ts
@@ -13,7 +13,7 @@ export class FindUserServiceTest extends BaseTest {
     expect(user.username).toEqual('admin')
     expect(user.email).toBeUndefined()
     expect(user.name).toBeUndefined()
-    expect(user.organizationId).toBeUndefined()
+    expect(user.environmentId).toBeUndefined()
     expect(user.accessToken).toEqual(super.commonUserAccessToken())
   }
 


### PR DESCRIPTION
BREAKING CHANGE: organizationId removed from user

![gif-or-image](https://media.giphy.com/media/kPtv3UIPrv36cjxqLs/giphy.gif)

### What?

Rename organization to environment
### Why?

To met architectural design

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Renomear organization para environment](https://app.asana.com/0/1188321867452078/1199656680965699/f)

<!-- Add task card link -->
