### PR TITLE
refactor(mongo): support multiple module connections

### DIFF
--- a/packages/mongo/.env
+++ b/packages/mongo/.env
@@ -1,2 +1,1 @@
-DATABASE_URL='mongodb://extensions:extensions@localhost'
-DATABASE_NAME='mongo'
+MONGO_CONNECTION_URI='mongodb://extensions:extensions@localhost:27017/skoredb_dev?authSource=admin'

--- a/packages/mongo/src/client/mongo-db.client.ts
+++ b/packages/mongo/src/client/mongo-db.client.ts
@@ -1,26 +1,20 @@
-import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
+import { Injectable, Logger, OnApplicationShutdown, ShutdownSignal } from '@nestjs/common'
 import { Db, MongoClient } from 'mongodb'
 
 @Injectable()
 export class MongoDbClient implements OnApplicationShutdown {
-  private static connection: MongoClient
+  constructor(private readonly mongoClient: MongoClient) {}
 
-  async init(): Promise<Db> {
-    MongoDbClient.connection = await this.mongoClient()
-
-    return MongoDbClient.connection.db(process.env.DATABASE_NAME)
+  async db(): Promise<Db> {
+    const database = await this.mongoClient.connect()
+    return database.db()
   }
 
-  async onApplicationShutdown(signal: string): Promise<void> {
+  async onApplicationShutdown(signal: ShutdownSignal): Promise<void> {
     Logger.debug(`Application received shutdown with signal: ${signal}.`, MongoDbClient.name)
-    if (MongoDbClient.connection?.isConnected()) await MongoDbClient.connection.close()
-    Logger.debug('Connection with MongoDb closed. ', MongoDbClient.name)
-  }
 
-  private async mongoClient(): Promise<MongoClient> {
-    return MongoClient.connect(process.env.DATABASE_URL, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    })
+    if (this.mongoClient?.isConnected()) await this.mongoClient.close()
+
+    Logger.debug('Connection with MongoDb closed. ', MongoDbClient.name)
   }
 }

--- a/packages/mongo/src/domain/constants.ts
+++ b/packages/mongo/src/domain/constants.ts
@@ -1,0 +1,1 @@
+export const MONGO_MODULE_OPTS = Symbol('MONGO_MODULE_OPTS')

--- a/packages/mongo/src/domain/index.ts
+++ b/packages/mongo/src/domain/index.ts
@@ -1,0 +1,2 @@
+export * from './constants'
+export * from './mongo-module.options'

--- a/packages/mongo/src/domain/mongo-module.options.ts
+++ b/packages/mongo/src/domain/mongo-module.options.ts
@@ -1,0 +1,14 @@
+import { FactoryProvider } from '@nestjs/common'
+
+export type MongoConnection = {
+  /**
+   * Connection string with database name
+   *
+   * @example <caption>Connecting to `contents` database with user: `user` pass: `pass` on `locahost:27017` with poolSize 10</caption>
+   * `mongodb://user:pass@localhost:27017/contents?poolSize=10&appname=YOUR_APP_NAME`
+   *
+   * */
+  connection: string
+}
+
+export type MongoModuleOptions = Omit<FactoryProvider<MongoConnection>, 'provide'>

--- a/packages/mongo/src/mongo.module.ts
+++ b/packages/mongo/src/mongo.module.ts
@@ -1,19 +1,90 @@
-import { Module } from '@nestjs/common'
-import { Db } from 'mongodb'
+import { DynamicModule } from '@nestjs/common'
+import { Db, MongoClient } from 'mongodb'
 import { MongoDbClient } from './client'
+import { MongoConnection, MongoModuleOptions, MONGO_MODULE_OPTS } from './domain'
 import { EnsureIndexesService } from './service'
 
-@Module({
-  providers: [
-    EnsureIndexesService,
-    MongoDbClient,
-    {
-      provide: Db,
-      useFactory: async (): Promise<Db> => {
-        return new MongoDbClient().init()
-      },
-    },
-  ],
-  exports: [Db],
-})
-export class MongoModule {}
+/**
+ *  Module to init a mongodb connection
+ *
+ *  This module creates a new mongodb connection for each import
+ *  by design, the reason for it is an application that connects
+ *  to multiple databases with differents username/password or
+ *  even different databases hosts.
+ *
+ *  This module provide two providers `Db` and `EnsureIndex` decorator
+ *
+ *  @param options - FactoryProvider which returns `connection: string` in useFactory method
+ *
+ *  @example <caption>Using Nest's ConfigModule</caption>
+ *  ```typescript
+ *  MongoModule.register({
+ *    useFactory: (configService: ConfigService) => ({
+ *      connection: configService.get('MONGO_CONNECTION_URI'),
+ *    }),
+ *    inject: [ConfigService],
+ *  })
+ *  ```
+ *
+ *  Note: You can pass a hard-coded connection string without inject
+ *  and params on useFactory function.
+ *
+ *  @example <caption>Using Db in a provider</caption>
+ *
+ *  ```typescript
+ *  @Injectable()
+ *  export class ContentDocument {
+ *    private readonly collection: Collection;
+ *    constructor(private readonly db: Db) {
+ *      this.collection = db.collection('contents');
+ *    }
+ *  }
+ *  ```
+ *
+ *  This way you can use `this.collection` to interact with collection
+ *
+ *  This module register a ShutdownHook for any signal. You **must** enable
+ *  shutdownHooks in your main file.
+ *
+ *  @example <caption>Enabling shutdown hooks</caption>
+ *
+ *  ```ts
+ *  const app = await NestFactory.create(AppModule);
+ *  app.enableShutdownHooks();
+ *  await app.listen(3000);
+ *  ```
+ *
+ *  If shutdown hooks is disabled connections will remain after app shutdown.
+ */
+export class MongoModule {
+  static register(options: MongoModuleOptions): DynamicModule {
+    return {
+      module: MongoModule,
+      providers: [
+        EnsureIndexesService,
+        {
+          provide: MongoDbClient,
+          useFactory: async (options: MongoConnection): Promise<MongoDbClient> => {
+            const connection = await MongoClient.connect(options.connection, {
+              useUnifiedTopology: true,
+              useNewUrlParser: true,
+            })
+            return new MongoDbClient(connection)
+          },
+          inject: [MONGO_MODULE_OPTS],
+        },
+        {
+          provide: MONGO_MODULE_OPTS,
+          useFactory: options.useFactory,
+          inject: options.inject,
+        },
+        {
+          provide: Db,
+          useFactory: (mongoClient: MongoDbClient) => mongoClient.db(),
+          inject: [MongoDbClient],
+        },
+      ],
+      exports: [Db],
+    }
+  }
+}

--- a/packages/mongo/test/mongo/module/test.module.ts
+++ b/packages/mongo/test/mongo/module/test.module.ts
@@ -1,13 +1,19 @@
 import { Global, Module } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
+import { ConfigModule, ConfigService } from '@nestjs/config'
 import { MongoModule } from '../../../src'
 
 @Global()
 @Module({
   imports: [
-    MongoModule,
+    MongoModule.register({
+      useFactory: (configService: ConfigService) => ({
+        connection: configService.get('MONGO_CONNECTION_URI'),
+      }),
+      inject: [ConfigService],
+    }),
     ConfigModule.forRoot({
       isGlobal: true,
+      ignoreEnvVars: true,
     }),
   ],
   exports: [MongoModule],


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/thkZDBh0wCsRXU5MCq/giphy.gif)

### What?
Create one `Db` instance provider for each module register

### Why?
To support `skore-one` with multiple `extensions` and each one access a different database with it's own credentials