### PR TITLE
fix: class-transformer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@nestjs/config": "^0.5.0",
     "@nestjs/platform-express": "^7.4.4",
     "axios": "^0.21.0",
-    "class-transformer": "^0.3.1",
+    "class-transformer": "0.3.1",
     "mongodb": "^3.6.2",
     "nestjs-redis": "^1.2.8"
   },

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -22,7 +22,6 @@
     "test": "npx jest --detectOpenHandles"
   },
   "dependencies": {
-    "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2"
   }
 }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/VZ5gRT17YNkn6/giphy.gif)

### What?

Adjust `class-transformer` version.

### Why?

We had the same problem in other project, fixed in [this PR](https://github.com/skore-io/skore-one-extension-evaluation/pull/19).
