### PR TITLE
refactor(keycloak): change permission scopes

### DIFF
--- a/packages/keycloak/realm.json
+++ b/packages/keycloak/realm.json
@@ -923,10 +923,10 @@
             "uris": [],
             "scopes": [
               {
-                "name": "delete"
+                "name": "view"
               },
               {
-                "name": "create"
+                "name": "edit"
               }
             ]
           },
@@ -939,7 +939,7 @@
             "uris": [],
             "scopes": [
               {
-                "name": "delete"
+                "name": "edit"
               }
             ]
           }
@@ -963,7 +963,7 @@
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
-              "scopes": "[\"list\",\"update\",\"create\",\"delete\"]",
+              "scopes": "[\"view\",\"edit\"]",
               "applyPolicies": "[\"All Skoreans Policy\"]"
             }
           }
@@ -971,23 +971,11 @@
         "scopes": [
           {
             "id": "f2ee711b-c731-4509-a3eb-f313933f7d42",
-            "name": "create"
+            "name": "view"
           },
           {
             "id": "de7d83ef-1123-4d3f-8b74-86d2a1b8435a",
-            "name": "delete"
-          },
-          {
-            "id": "7ed9c5a6-c9bc-4f51-b9b9-4dd201712974",
-            "name": "update"
-          },
-          {
-            "id": "d3a8d0d3-bb60-4eef-bc1d-9dc173abad31",
-            "name": "find"
-          },
-          {
-            "id": "f4c5b583-0b77-44bf-8b7b-90807907117c",
-            "name": "list"
+            "name": "edit"
           }
         ],
         "decisionStrategy": "UNANIMOUS"

--- a/packages/keycloak/src/domain/index.ts
+++ b/packages/keycloak/src/domain/index.ts
@@ -1,2 +1,3 @@
 export * from './resource.domain'
 export * from './user.domain'
+export * from './scope-type.domain'

--- a/packages/keycloak/src/domain/resource.domain.ts
+++ b/packages/keycloak/src/domain/resource.domain.ts
@@ -1,13 +1,8 @@
 import { Expose, Transform } from 'class-transformer'
+import { ScopeType } from './scope-type.domain'
 
 export class Resource {
-  static readonly DEFAULT_SCOPES = [
-    { name: 'create' },
-    { name: 'update' },
-    { name: 'delete' },
-    { name: 'list' },
-    { name: 'find' },
-  ]
+  static readonly DEFAULT_SCOPES = Object.values(ScopeType).map(scopeType => ({ name: scopeType }))
 
   constructor(name: string, displayName: string) {
     this.name = name
@@ -29,5 +24,5 @@ export class Resource {
 
   @Transform(value => value || Resource.DEFAULT_SCOPES)
   @Expose()
-  scopes?: { name: string }[] = Resource.DEFAULT_SCOPES
+  scopes?: { name: ScopeType }[] = Resource.DEFAULT_SCOPES
 }

--- a/packages/keycloak/src/domain/scope-type.domain.ts
+++ b/packages/keycloak/src/domain/scope-type.domain.ts
@@ -1,0 +1,4 @@
+export enum ScopeType {
+  VIEW = 'view',
+  EDIT = 'edit',
+}

--- a/packages/keycloak/src/service/check-resource-permission.service.ts
+++ b/packages/keycloak/src/service/check-resource-permission.service.ts
@@ -1,14 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { stringify } from 'querystring'
 import { CheckResourcePermissionClient } from '../client'
-import { User } from '../domain'
+import { ScopeType, User } from '../domain'
 import { KeycloakUtils } from '../utils'
 
 @Injectable()
 export class CheckResourcePermissionService {
   constructor(private readonly resourceClient: CheckResourcePermissionClient) {}
 
-  async perform(user: User, resources: string[], scope: string): Promise<void> {
+  async perform(user: User, resources: string[], scope: ScopeType): Promise<void> {
     try {
       if (resources.length === 0 || !scope) throw Error('Invalid params')
 

--- a/packages/keycloak/src/service/get-resource-permissions.service.ts
+++ b/packages/keycloak/src/service/get-resource-permissions.service.ts
@@ -2,13 +2,13 @@ import { Injectable, Logger } from '@nestjs/common'
 import { KeycloakUtils } from '../utils'
 import { stringify } from 'qs'
 import { GetResourcePermissionsClient } from '../client'
-import { User } from '../domain'
+import { ScopeType, User } from '../domain'
 
 @Injectable()
 export class GetResourcePermissionsService {
   constructor(private readonly getResourcePermissions: GetResourcePermissionsClient) {}
 
-  async perform(user: User, resources: string[], scope: string): Promise<string[]> {
+  async perform(user: User, resources: string[], scope: ScopeType): Promise<string[]> {
     if (resources.length === 0 || !scope) throw Error('Invalid params')
 
     try {

--- a/packages/keycloak/test/factory/policy.factory.ts
+++ b/packages/keycloak/test/factory/policy.factory.ts
@@ -9,7 +9,7 @@ export class PolicyFactory {
       `${process.env.KEYCLOAK_SERVER_URL}/auth/realms/skore/authz/protection/uma-policy/18ee88a4-cd72-4e0d-9304-15abe6101b45`,
       {
         name: faker.name.title(),
-        scopes: ['create'],
+        scopes: ['edit'],
         users: userIds,
       },
       {

--- a/packages/keycloak/test/service/check-resource-permission.service.test.ts
+++ b/packages/keycloak/test/service/check-resource-permission.service.test.ts
@@ -1,5 +1,5 @@
 import { suite, test } from '@testdeck/jest'
-import { User } from '../../src/domain'
+import { ScopeType, User } from '../../src/domain'
 import { CheckResourcePermissionService } from '../../src/service'
 import { BaseTest } from '../base-test'
 import { PolicyFactory } from '../factory'
@@ -18,7 +18,7 @@ export class CheckResourcePermissionServiceTest extends BaseTest {
   @test()
   async 'Given an user with access in resource dont throws an error'() {
     const service = super.get(CheckResourcePermissionService)
-    await service.perform(this.user, ['Movies', 'Downloads'], 'create')
+    await service.perform(this.user, ['Movies', 'Downloads'], ScopeType.EDIT)
   }
 
   @test()
@@ -27,7 +27,7 @@ export class CheckResourcePermissionServiceTest extends BaseTest {
     const service = super.get(CheckResourcePermissionService)
 
     try {
-      await service.perform(this.user, ['Downloads'], 'create')
+      await service.perform(this.user, ['Downloads'], ScopeType.EDIT)
     } catch (error) {
       expect(error.message).toEqual('Permission Denied')
     }

--- a/packages/keycloak/test/service/get-resource-permissions.service.test.ts
+++ b/packages/keycloak/test/service/get-resource-permissions.service.test.ts
@@ -1,5 +1,5 @@
 import { suite, test } from '@testdeck/jest'
-import { User } from '../../src/domain'
+import { ScopeType, User } from '../../src/domain'
 import { GetResourcePermissionsService } from '../../src/service'
 import { BaseTest } from '../base-test'
 import { PolicyFactory } from '../factory'
@@ -19,7 +19,7 @@ export class GetResourcePermissionsServiceTest extends BaseTest {
   async 'Given resources list then those with permission are returned'() {
     const service = super.get(GetResourcePermissionsService)
 
-    const resources = await service.perform(this.user, ['Movies', 'Downloads'], 'create')
+    const resources = await service.perform(this.user, ['Movies', 'Downloads'], ScopeType.EDIT)
 
     expect(resources).toEqual(['Movies'])
   }
@@ -29,7 +29,7 @@ export class GetResourcePermissionsServiceTest extends BaseTest {
     const service = super.get(GetResourcePermissionsService)
 
     try {
-      await service.perform(this.user, ['Movies'], 'delete')
+      await service.perform(this.user, ['Movies'], ScopeType.EDIT)
     } catch (error) {
       expect(error.message).toEqual('Permission Denied')
     }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/XevlqTyQdJ9BP4TvKS/giphy.gif)

### What?

Change the keycloak permission scopes.

### Why?

Because we will not have such granular permission.

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Criar Permissão](https://app.asana.com/0/1188321867452078/1199943788930050/f)
