### PR TITLE
refactor(keycloak): search resource id to create permission

### DIFF
--- a/packages/keycloak/src/domain/permission.domain.ts
+++ b/packages/keycloak/src/domain/permission.domain.ts
@@ -27,7 +27,7 @@ export class Permission {
   @IsNotEmpty({ groups: ['create'] })
   scope: ScopeType
 
-  @ValidateIf(self => !self.groups.length)
+  @ValidateIf(self => !self.groups.length, { groups: ['create'] })
   @ArrayNotEmpty({ message: 'Users or groups should not be empty', groups: ['create'] })
   users?: string[] = []
 

--- a/packages/keycloak/src/service/create-permission.service.ts
+++ b/packages/keycloak/src/service/create-permission.service.ts
@@ -48,9 +48,15 @@ export class CreatePermissionService {
 
       return permission
     } catch (error) {
-      Logger.error('Error on trying to create permission', error, CreatePermissionService.name)
+      const errorDescription = error.response?.data?.error_description || error
 
-      throw error
+      Logger.error(
+        'Error on trying to create permission',
+        errorDescription,
+        CreatePermissionService.name,
+      )
+
+      throw errorDescription
     }
   }
 }

--- a/packages/keycloak/src/service/create-permission.service.ts
+++ b/packages/keycloak/src/service/create-permission.service.ts
@@ -1,37 +1,46 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { CreatePermissionClient, GetClientToken } from '../client'
+import { FindResourceService } from './find-resource.service'
 import { Permission } from '../domain'
 import { KeycloakUtils } from '../utils'
 
-type CreatePermission = Omit<Permission, 'id' | 'name'>
+type CreatePermission = Omit<Permission, 'id' | 'name' | 'resourceId'>
 
 @Injectable()
 export class CreatePermissionService {
   constructor(
     private readonly createPermissionClient: CreatePermissionClient,
     private readonly getClientToken: GetClientToken,
+    private readonly findResourceService: FindResourceService,
     private readonly configService: ConfigService,
   ) {}
 
-  async perform(token: string, createPermission: CreatePermission): Promise<Permission> {
-    const { groups, users, resourceId, scope } = createPermission
-    const name = `${resourceId}_${scope}`
-    const permission = new Permission(name, resourceId, scope, users, groups)
+  async perform(
+    token: string,
+    resourceName: string,
+    createPermission: CreatePermission,
+  ): Promise<Permission> {
+    const { groups, users, scope } = createPermission
 
     try {
-      await Permission.validate(permission, 'create')
-
-      Logger.log(`Creating permission ${permission.name} in keycloak`, CreatePermissionService.name)
+      if (!resourceName) throw Error('Resource is required')
 
       const realm = KeycloakUtils.realmFromToken(token)
-
       const {
         data: { access_token: accessToken },
       } = await this.getClientToken.getClient(
         realm,
         this.configService.get('KEYCLOAK_FOLDER_CLIENT_ID'),
       )
+
+      const resourceId = await this.findResourceService.perform(realm, accessToken, resourceName)
+      const name = `${resourceId}_${scope}`
+      const permission = new Permission(name, resourceId, scope, users, groups)
+
+      await Permission.validate(permission, 'create')
+
+      Logger.log(`Creating permission ${permission.name} in keycloak`, CreatePermissionService.name)
 
       const { data } = await this.createPermissionClient.create(realm, accessToken, permission)
 

--- a/packages/keycloak/test/service/create-permission.service.test.ts
+++ b/packages/keycloak/test/service/create-permission.service.test.ts
@@ -10,8 +10,7 @@ export class CreatePermissionServiceTest extends BaseTest {
   async 'Given a permission with users and groups then create'() {
     const resource = await new ResourceFactory().create()
     const service = super.get(CreatePermissionService)
-    const response = await service.perform(super.token(), {
-      resourceId: resource.id,
+    const response = await service.perform(super.token(), resource.name, {
       scope: ScopeType.VIEW,
       groups: ['Skoreans'],
       users: ['24b0a4bf-e796-4ede-9257-734fa0314a40'],
@@ -25,26 +24,24 @@ export class CreatePermissionServiceTest extends BaseTest {
   }
 
   @test()
-  async 'Given a permission without resourceId then throw error'() {
+  async 'Given a permission without resource then throw error'() {
     const service = super.get(CreatePermissionService)
 
-    try {
-      await service.perform(super.token(), {
-        resourceId: null,
-        scope: ScopeType.EDIT,
-        users: ['12345'],
-      })
-    } catch ([error]) {
-      expect(error.constraints.isNotEmpty).toEqual('resourceId should not be empty')
-    }
+    const promise = service.perform(super.token(), null, {
+      scope: ScopeType.EDIT,
+      users: ['12345'],
+    })
+
+    await expect(promise).rejects.toThrow('Resource is required')
   }
 
   @test()
   async 'Given a permission without users and groups then throw error'() {
+    const resource = await new ResourceFactory().create()
     const service = super.get(CreatePermissionService)
 
     try {
-      await service.perform(super.token(), { resourceId: '12345', scope: ScopeType.VIEW })
+      await service.perform(super.token(), resource.name, { scope: ScopeType.VIEW })
     } catch ([error]) {
       expect(error.constraints.arrayNotEmpty).toEqual('Users or groups should not be empty')
     }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/l0MYD0wjKQ84goG6A/giphy.gif)

### What?

Receive `resource name` in create permission method, and search `resource id`.

### Why?

Because we don't have the `resource id` in skore-one.

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Criar Permissão](https://app.asana.com/0/1188321867452078/1199943788930050/f)
