### PR TITLE
feat: handle 500 when updating permission

### DIFF
--- a/packages/keycloak/src/errors/error.ts
+++ b/packages/keycloak/src/errors/error.ts
@@ -1,0 +1,5 @@
+import { UnprocessableEntityException } from '@nestjs/common'
+
+export class Error {
+  static UNPROCESSABLE_ENTITY = new UnprocessableEntityException('UNPROCESSABLE_ENTITY')
+}

--- a/packages/keycloak/src/errors/index.ts
+++ b/packages/keycloak/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './error'

--- a/packages/keycloak/src/service/update-permission.service.ts
+++ b/packages/keycloak/src/service/update-permission.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { GetClientToken, UpdatePermissionClient } from '../client'
 import { Permission } from '../domain'
+import { Error } from '../errors'
 import { KeycloakUtils } from '../utils'
 
 @Injectable()
@@ -32,6 +33,10 @@ export class UpdatePermissionService {
       return permission
     } catch (error) {
       Logger.error('Error on trying to update permission', error, UpdatePermissionClient.name)
+
+      if (error.message.match(/status code 500/)) {
+        throw Error.UNPROCESSABLE_ENTITY
+      }
 
       throw error
     }

--- a/packages/keycloak/test/service/update-permission.service.test.ts
+++ b/packages/keycloak/test/service/update-permission.service.test.ts
@@ -1,5 +1,6 @@
 import { HttpService } from '@nestjs/common'
 import { suite, test } from '@testdeck/jest'
+import { Error } from '../../src/errors'
 import { Permission, ScopeType } from '../../src/domain'
 import { CreatePermissionService, UpdatePermissionService } from '../../src/service'
 import { BaseTest } from '../base-test'
@@ -21,6 +22,17 @@ export class UpdatePermissionServiceTest extends BaseTest {
     expect(updatedPermission.name).toEqual(`${permission.resourceId}_${ScopeType.VIEW}`)
     expect(updatedPermission.users).toHaveLength(0)
     expect(updatedPermission.groups).toHaveLength(1)
+  }
+
+  @test()
+  async 'Given a not fout user throws UNPROCESSABLE_ENTITY'() {
+    const permission = await this.createPermission()
+
+    permission.users = ['user-not-found']
+    const service = super.get(UpdatePermissionService)
+    const promise = service.perform(super.token(), permission)
+
+    await expect(promise).rejects.toThrow(Error.UNPROCESSABLE_ENTITY)
   }
 
   @test()

--- a/packages/keycloak/test/service/update-permission.service.test.ts
+++ b/packages/keycloak/test/service/update-permission.service.test.ts
@@ -25,7 +25,7 @@ export class UpdatePermissionServiceTest extends BaseTest {
   }
 
   @test()
-  async 'Given a not fout user throws UNPROCESSABLE_ENTITY'() {
+  async 'Given a not found user throws UNPROCESSABLE_ENTITY'() {
     const permission = await this.createPermission()
 
     permission.users = ['user-not-found']


### PR DESCRIPTION


![gif-or-image](https://media.giphy.com/media/Vo6xlTxdhpAoU/giphy.gif)

### What?

Retruns an unpeocessable entity error when keycloak returns 500

### Why?

To help client to handle the error

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Editar Permissão](https://app.asana.com/0/1188321867452078/1199943788930051/f)

<!-- Add task card link -->
