### PR TITLE
feat: add auth current decorator

### DIFF
--- a/packages/auth/src/decorator/current.decorator.ts
+++ b/packages/auth/src/decorator/current.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common'
+import { getRequestFromContext } from '../util'
+
+export const Current = createParamDecorator(
+  (_params: unknown, context: ExecutionContext) => getRequestFromContext(context).current,
+)

--- a/packages/auth/src/decorator/index.ts
+++ b/packages/auth/src/decorator/index.ts
@@ -1,3 +1,4 @@
+export * from './current.decorator'
 export * from './current-user.decorator'
 export * from './current-company.decorator'
 export * from './is-company.decorator'

--- a/packages/auth/src/domain/index.ts
+++ b/packages/auth/src/domain/index.ts
@@ -1,2 +1,3 @@
 export * from './company.domain'
+export * from './user-or-company.domain'
 export * from './user.domain'

--- a/packages/auth/src/domain/user-or-company.domain.ts
+++ b/packages/auth/src/domain/user-or-company.domain.ts
@@ -1,0 +1,10 @@
+import { Expose } from 'class-transformer'
+import { Company, User } from '.'
+
+export class UserOrCompany {
+  @Expose()
+  user: User
+
+  @Expose()
+  company: Company
+}

--- a/packages/auth/test/strategy/admin-or-company.strategy.test.ts
+++ b/packages/auth/test/strategy/admin-or-company.strategy.test.ts
@@ -20,7 +20,7 @@ export class AdminOrCompanyStrategy extends BaseTest {
     const companyToken = jwt.sign({ companyId: '114' }, 'secretkey', { algorithm: 'HS384' })
     const companyStrategy = await super.get(Strategy).validate({ context }, companyToken)
 
-    expect(companyStrategy.id).toEqual(this.company.id)
+    expect(companyStrategy.company.id).toEqual(this.company.id)
   }
 
   @test
@@ -31,7 +31,7 @@ export class AdminOrCompanyStrategy extends BaseTest {
     const userToken = jwt.sign(this.user, 'secretkey', { algorithm: UserOrCompanyAlg.USER })
     const userStrategy = await super.get(Strategy).validate({ context }, userToken)
 
-    expect(userStrategy.id).toEqual(this.user.id)
+    expect(userStrategy.user.id).toEqual(this.user.id)
   }
 
   @test
@@ -42,7 +42,7 @@ export class AdminOrCompanyStrategy extends BaseTest {
     const userToken = jwt.sign(this.user, 'secretkey', { algorithm: UserOrCompanyAlg.USER })
     const userStrategy = await super.get(Strategy).validate({ context }, userToken)
 
-    expect(userStrategy.id).toEqual(this.user.id)
+    expect(userStrategy.user.id).toEqual(this.user.id)
   }
 
   @test


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/7zPmi9E6llz9abCyvZ/giphy-downsized.gif)

### What?

- Adds a decorator named `Current` to fetch user or company in the request;

### Why?

- Because both user or company were being added into `req.user`, which is semantically wrong, considering we separate user and companies in the lib;

### Any?

- I've chosen only `Current` as the decorator name to fetch it, but I am open to suggestions of better names;

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [Criar um decorator para autenticar companies e usuários admin](https://app.asana.com/0/1201668652840883/1201639344118681/f)

<!-- Add task card link -->
