### PR TITLE
fix(event): remove common dependency and update enum

### DIFF
--- a/packages/event/README.md
+++ b/packages/event/README.md
@@ -57,6 +57,4 @@ const body = {
 }
 
 await sendEvent.perform(attributes, body)
-
-this.logger.log('New message send with succeffully!')
 ```

--- a/packages/event/src/client/pub-sub.client.ts
+++ b/packages/event/src/client/pub-sub.client.ts
@@ -21,21 +21,25 @@ export class PubSubClient implements EventClientInterface {
 
       await validateOrReject(attributesPubSubDto)
     } catch (error) {
-      const errorsValidations: ValidationError[] = error
-      let objectError = {}
-      for (const item of errorsValidations) {
-        for (const key in item.constraints) {
-          if (key) {
-            objectError = {
-              message: item.constraints[key],
-              ...(item.value && { informedValue: item.value }),
-            }
+      const throwError = Array.isArray(error) ? this.formatValidationError(error) : error
+
+      throw new ValidationAttributeError(throwError)
+    }
+  }
+
+  private formatValidationError(error: ValidationError[]): object {
+    let objectError = {}
+    for (const item of error) {
+      for (const key in item.constraints) {
+        if (key) {
+          objectError = {
+            message: item.constraints[key],
+            ...(item.value && { informedValue: item.value }),
           }
         }
       }
-
-      throw new ValidationAttributeError(objectError)
     }
+    return objectError
   }
 
   async publish(attributes: PubSubAttributeDto, body: object): Promise<void> {

--- a/packages/event/src/enum/pub-sub.enum.ts
+++ b/packages/event/src/enum/pub-sub.enum.ts
@@ -14,6 +14,7 @@ export enum PubSubTypeEventEnum {
 }
 
 export enum PubSubActionEnum {
+  send_push = 'send_push',
   accessed = 'accessed',
   partial_consumed = 'partial_consumed',
   consumed = 'consumed',

--- a/packages/event/src/error/coded.error.ts
+++ b/packages/event/src/error/coded.error.ts
@@ -1,8 +1,10 @@
 export abstract class CodedError extends Error {
   code: string
+  details?: object
 
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, details?: object) {
     super(message)
     this.code = code
+    this.details = details
   }
 }

--- a/packages/event/src/error/publish-pub-sub.error.ts
+++ b/packages/event/src/error/publish-pub-sub.error.ts
@@ -1,7 +1,7 @@
 import { CodedError } from './coded.error'
 
 export class PublishPubSubError extends CodedError {
-  constructor() {
-    super('PUBLISH_PUBSUB_FAILED', 'fail to publish event')
+  constructor(errorDetails: object) {
+    super('PUBLISH_PUBSUB_FAILED', 'fail to publish event', errorDetails)
   }
 }

--- a/packages/event/src/error/validation-attribute.error.ts
+++ b/packages/event/src/error/validation-attribute.error.ts
@@ -1,7 +1,7 @@
 import { CodedError } from './coded.error'
 
 export class ValidationAttributeError extends CodedError {
-  constructor() {
-    super('VALIDATION_FAILED', 'Invalid attributes data')
+  constructor(errorDetails: object) {
+    super('VALIDATION_FAILED', 'Invalid attributes data', errorDetails)
   }
 }

--- a/packages/event/test/client/pub-sub.client.test.ts
+++ b/packages/event/test/client/pub-sub.client.test.ts
@@ -71,6 +71,7 @@ export class GetClientTest {
     expect(err).toBeInstanceOf(PublishPubSubError)
     expect((err as PublishPubSubError).code).toEqual('PUBLISH_PUBSUB_FAILED')
     expect((err as PublishPubSubError).message).toEqual('fail to publish event')
+    expect((err as PublishPubSubError).details).toEqual(errorFake)
   }
 
   @test()
@@ -81,7 +82,7 @@ export class GetClientTest {
 
     const attributePubSubDtoFake = {
       action: 'yolo',
-      gcp_events_project: 1,
+      type: PubSubTypeEventEnum['io.skore.events.messaging.conversation'],
       source: 'workspace:???.ts',
     }
 
@@ -96,6 +97,36 @@ export class GetClientTest {
 
     expect(err).toBeInstanceOf(ValidationAttributeError)
     expect((err as ValidationAttributeError).code).toEqual('VALIDATION_FAILED')
-    expect((err as ValidationAttributeError).message).toEqual('Invalid attributes data')
+    expect((err as ValidationAttributeError).details).toEqual({
+      message: 'action must be a valid enum value',
+      informedValue: 'yolo',
+    })
+  }
+
+  @test()
+  async 'Should throw ValidationAttributeError at validate attributes empty '() {
+    const getClient = {}
+
+    const pubSubClient = new PubSubClient({ getClient })
+
+    const attributePubSubDtoFake = {
+      type: PubSubTypeEventEnum['io.skore.events.messaging.conversation'],
+      source: 'workspace:???.ts',
+    }
+
+    let err = null
+    try {
+      /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+      // @ts-ignore
+      await pubSubClient.validate(attributePubSubDtoFake)
+    } catch (error) {
+      err = error
+    }
+
+    expect(err).toBeInstanceOf(ValidationAttributeError)
+    expect((err as ValidationAttributeError).code).toEqual('VALIDATION_FAILED')
+    expect((err as ValidationAttributeError).details).toEqual({
+      message: 'action should not be empty',
+    })
   }
 }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/xZsLh7B3KMMyUptD9D/giphy.gif)

### What?

Necessidade de usar a lib envio de evento através da lambda notification_find_target

### Why?

- atualização do enum de actions necessária para o uso na lambda mencionada. 
- remover pacote do framework nest (cammon) e assim poder usar em qualquer projeto javascript/typscript. 
