### PR TITLE
fix(event): change camel case createAt to snake case

### DIFF
--- a/packages/event/src/client/pub-sub.client.ts
+++ b/packages/event/src/client/pub-sub.client.ts
@@ -51,7 +51,7 @@ export class PubSubClient implements EventClientInterface {
 
   async publish(attributes: PubSubAttributeDto, body: object): Promise<void> {
     const pubSubClient = await this.googleAuth.getClient()
-    const defaultAttributes = { createdAt: String(Date.now()) }
+    const defaultAttributes = { created_at: String(Date.now()) }
 
     try {
       await pubSubClient.request({

--- a/packages/event/test/client/pub-sub.client.test.ts
+++ b/packages/event/test/client/pub-sub.client.test.ts
@@ -28,7 +28,7 @@ export class GetClientTest {
 
     await pubSubClient.publish(pubSubAttributeFake, bodyFake)
 
-    const defaultAttributes = { createdAt: String(Date.now()) }
+    const defaultAttributes = { created_at: String(Date.now()) }
 
     expect(getClient).toHaveBeenCalledTimes(1)
     expect(request).toHaveBeenCalledWith({


### PR DESCRIPTION
### What?

Fix para alterar camelcase para snake_case

### Why?

os eventos que são publicados pela lib estão ficando com o created_at em camelcase, e isso está gerando problemas nos relatorios.



