### PR TITLE
fix: max milli seconds

### DIFF
--- a/packages/event/src/client/pub-sub.client.ts
+++ b/packages/event/src/client/pub-sub.client.ts
@@ -83,7 +83,7 @@ export class PubSubClient implements EventClientInterface {
     const batchPublisher = pubSubClient.topic('events', {
       batching: {
         maxMessages: this.BATCH_SIZE,
-        maxMilliseconds: 60 * 1000,
+        maxMilliseconds: messages.length * 1000,
       },
     })
 


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/iO4ptP2iuV29yui3mx/giphy.gif)

### What?

- Resolve o milli seconds;

### Why?

Para não demorar o envio do batch;
