### PR TITLE
fix: remove max milli seconds

### DIFF
--- a/packages/event/src/client/pub-sub.client.ts
+++ b/packages/event/src/client/pub-sub.client.ts
@@ -82,8 +82,7 @@ export class PubSubClient implements EventClientInterface {
 
     const batchPublisher = pubSubClient.topic('events', {
       batching: {
-        maxMessages: messages.length,
-        maxMilliseconds: 60 * 1000,
+        maxMessages: this.BATCH_SIZE,
       },
     })
 


### PR DESCRIPTION
![gif-or-image]()

### What?

- Remove max milli seconds;

### Why?

Pois está atrasando o envio das mensagens;
