### PR TITLE
chore(event): add news enums to feature live course

### DIFF
--- a/packages/event/src/enum/pub-sub.enum.ts
+++ b/packages/event/src/enum/pub-sub.enum.ts
@@ -39,5 +39,5 @@ export enum PubSubActionEnum {
   created = 'created',
   reindex = 'reindex',
   enrollment_file_uploaded = 'enrollment_file_uploaded',
-  subscription_row_processed = 'subscription_row_processed',
+  enrollment_row_processed = 'enrollment_row_processed',
 }

--- a/packages/event/src/enum/pub-sub.enum.ts
+++ b/packages/event/src/enum/pub-sub.enum.ts
@@ -1,5 +1,6 @@
 export enum PubSubTypeEventEnum {
   'io.skore.events.content' = 'io.skore.events.content',
+  'io.skore.events.content.live_course' = 'io.skore.events.content.live_course',
   'io.skore.events.session' = 'io.skore.events.session',
   'io.skore.events.enrollment' = 'io.skore.events.enrollment',
   'io.skore.events.user' = 'io.skore.events.user',
@@ -37,4 +38,6 @@ export enum PubSubActionEnum {
   base_notification_dispatch = 'base_notification_dispatch',
   created = 'created',
   reindex = 'reindex',
+  enrollment_file_uploaded = 'enrollment_file_uploaded',
+  subscription_row_processed = 'subscription_row_processed',
 }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/yeUofEHWvMcyPQfWRJ/giphy.gif)

### What?

Necessidade de atualizar enums da lib de eventos.

### Why?

Para ser utilizado na solução de inscrição em massa.

<!-- Tell the world why is this so important -->
