### PR TITLE
fix: use correct workspace domain

### DIFF
--- a/packages/auth/src/client/workspace.client.ts
+++ b/packages/auth/src/client/workspace.client.ts
@@ -27,7 +27,7 @@ export class WorkspaceClient {
   }
 
   async getCompany(token: string): Promise<Company> {
-    const request = this.httpService.get(`${this.authBaseUrl}/api/v1/companies/current`, {
+    const request = this.httpService.get(`${this.authBaseUrl}/workspace/v1/companies/current`, {
       headers: { Authorization: token },
     })
 


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/fpWvGPAjq51MsN3sF6/giphy-downsized.gif)

### What?

Utiliza o domain correto do workspace;

### Why?

Pois o /api aponta para um API Gateway diferente... que queremos deprecar;
