### PR TITLE
feat(event): publish in batch

### DIFF
--- a/packages/event/README.md
+++ b/packages/event/README.md
@@ -23,7 +23,7 @@ GOOGLE_APPLICATION_CREDENTIALS='gcloud-service-account.json'
 
 ### Usage
 
-1. import and create attributes
+1. Import and create attributes
 
 ```typescript
 import {
@@ -59,13 +59,24 @@ const body = {
 await eventService.send(attributes, body)
 ```
 
-3. If you want to send events in batch, call method "sendInBatch" with attributes and an array of messages to send
+_If you want to send events in batch, call method "publishInBatch" with an array of attributes and messages_
 
 ```typescript
-const body = [
-  { test: 'yolo' },
-  { test: 'bilu' }
+const events = [
+  {
+    attributes: {
+      type: 'io.skore.events.content',
+      action: 'attended',
+      source: 'file.ts',
+      created_at: '1691600045063'
+    },
+    body: {
+      user_id: '3763039',
+      company_id: '17157',
+      live_class_id: 'd08753a0-ff90-458c-bf8e-48e6f7846b97'
+    }
+  }
 ]
 
-await eventService.sendInBatch(attributes, body)
+await eventService.publishInBatch(events)
 ```

--- a/packages/event/src/index.ts
+++ b/packages/event/src/index.ts
@@ -1,3 +1,4 @@
 export * from './service'
 export * from './enum'
 export * from './dto'
+export * from './type'

--- a/packages/event/src/interface/client.interface.ts
+++ b/packages/event/src/interface/client.interface.ts
@@ -1,7 +1,9 @@
 import { EventAttributeDto } from '../dto'
+import { PubSubEvent } from '../type'
 
 export interface EventClientInterface {
   publish(attributes: EventAttributeDto, body: object, url?: string): Promise<void>
   publishInBatch(attributes: EventAttributeDto, messages: object[]): Promise<void>
+  publishEventsInBatch(events: PubSubEvent[]): Promise<void>
   validate(attributes: EventAttributeDto): Promise<void>
 }

--- a/packages/event/src/service/event.service.ts
+++ b/packages/event/src/service/event.service.ts
@@ -3,6 +3,7 @@ import { EventAttributeDto } from '../dto'
 import { ClientEventNameEnum } from '../enum'
 import { PubSubClient } from '../client'
 import { ClientNotFoundError } from '../error'
+import { PubSubEvent } from '../type'
 
 export class EventService {
   private readonly client: EventClientInterface
@@ -29,9 +30,19 @@ export class EventService {
     await this.client.publish(attributes, body, eventUrl)
   }
 
+  /**
+   * @deprecated Use {@link publishInBatch} instead.
+   */
   async sendInBatch(attributes: EventAttributeDto, messages: object[]): Promise<void> {
     await this.client.validate(attributes)
 
     await this.client.publishInBatch(attributes, messages)
+  }
+
+  /**
+   * The maximum value of items in the batch is 1000
+   */
+  async publishInBatch(events: PubSubEvent[]): Promise<void> {
+    await this.client.publishEventsInBatch(events)
   }
 }

--- a/packages/event/src/type/event-attributes.type.ts
+++ b/packages/event/src/type/event-attributes.type.ts
@@ -1,0 +1,8 @@
+import { PubSubActionEnum, PubSubTypeEventEnum } from '../enum'
+
+export type EventAttributes = {
+  type: PubSubTypeEventEnum
+  action: PubSubActionEnum
+  source: string
+  created_at: string
+}

--- a/packages/event/src/type/index.ts
+++ b/packages/event/src/type/index.ts
@@ -1,0 +1,2 @@
+export * from './event-attributes.type'
+export * from './pubsub-event.type'

--- a/packages/event/src/type/pubsub-event.type.ts
+++ b/packages/event/src/type/pubsub-event.type.ts
@@ -1,0 +1,6 @@
+import { EventAttributes } from '../type'
+
+export type PubSubEvent = {
+  attributes: EventAttributes
+  body: { [key: string]: string }
+}

--- a/packages/event/test/client/pub-sub.client.test.ts
+++ b/packages/event/test/client/pub-sub.client.test.ts
@@ -142,7 +142,7 @@ export class GetClientTest {
         attributes: {
           action: PubSubActionEnum.completed,
           type: PubSubTypeEventEnum['io.skore.events.content'],
-          source: 'file.ts',
+          source: 'file2.ts',
           created_at: String(createdAt),
         },
         body: { user_id: '1234', content_id: '4321' },
@@ -158,6 +158,15 @@ export class GetClientTest {
         created_at: String(createdAt),
         source: 'file.ts',
         type: 'io.skore.events.messaging.conversation',
+      },
+      data: expect.any(Buffer),
+    })
+    expect(publishMessageSpy).toHaveBeenNthCalledWith(2, {
+      attributes: {
+        action: PubSubActionEnum.completed,
+        created_at: String(createdAt),
+        source: 'file2.ts',
+        type: 'io.skore.events.content',
       },
       data: expect.any(Buffer),
     })

--- a/packages/event/test/client/pub-sub.client.test.ts
+++ b/packages/event/test/client/pub-sub.client.test.ts
@@ -4,11 +4,12 @@ import { PubSubActionEnum, PubSubTypeEventEnum } from '../../src/enum'
 import { PubSubClient } from '../../src/client'
 import { PubSubAttributeDto } from '../../src'
 import { ValidationAttributeError, PublishPubSubError } from '../../src/error'
+import { PubSub } from '@google-cloud/pubsub'
 
 @suite('[Event Client] - PubSubClient')
 export class GetClientTest {
-  @test()
-  async 'Should publish event at Pub Sub with successfully'() {
+  @test
+  async '[publish] Should publish event at Pub Sub with successfully'() {
     process.env.GCP_EVENTS_PROJECT_URL = 'https://bilu.com.br/yolo'
 
     const request = jest.fn().mockResolvedValue(undefined)
@@ -32,7 +33,7 @@ export class GetClientTest {
 
     expect(getClient).toHaveBeenCalledTimes(1)
     expect(request).toHaveBeenCalledWith({
-      url: `https://bilu.com.br/yolo`,
+      url: 'https://bilu.com.br/yolo',
       method: 'POST',
       data: {
         messages: [
@@ -45,8 +46,8 @@ export class GetClientTest {
     })
   }
 
-  @test()
-  async 'Should publish event at Pub Sub with different environment variable'() {
+  @test
+  async '[publish] Should publish event at Pub Sub with different environment variable'() {
     process.env.GCP_EVENTS_PROJECT_URL = 'https://bilu.com.br/yolo'
 
     const request = jest.fn().mockResolvedValue(undefined)
@@ -83,8 +84,8 @@ export class GetClientTest {
     })
   }
 
-  @test()
-  async 'Should throw error to publish event'() {
+  @test
+  async '[publish] Should throw error to publish event'() {
     const errorFake = new Error('yolo error')
     const request = jest.fn().mockRejectedValue(errorFake)
     const getClient = jest.fn().mockResolvedValue({ request })
@@ -113,7 +114,68 @@ export class GetClientTest {
     expect((err as PublishPubSubError).details).toEqual(errorFake)
   }
 
-  @test()
+  @test
+  async '[publishEventsInBatch] Should publish batch of events in PubSub with successfully'() {
+    process.env.GCP_EVENTS_PROJECT_URL = 'https://bilu.com.br/yolo'
+
+    const pubSubClient = new PubSubClient()
+
+    const publishMessageSpy = jest.fn()
+
+    jest
+      .spyOn(PubSub.prototype, 'topic')
+      .mockImplementation(() => ({ publishMessage: publishMessageSpy } as never))
+
+    const createdAt = Date.now()
+
+    const events = [
+      {
+        attributes: {
+          action: PubSubActionEnum.sent,
+          type: PubSubTypeEventEnum['io.skore.events.messaging.conversation'],
+          source: 'file.ts',
+          created_at: String(createdAt),
+        },
+        body: { user_id: '1234' },
+      },
+      {
+        attributes: {
+          action: PubSubActionEnum.completed,
+          type: PubSubTypeEventEnum['io.skore.events.content'],
+          source: 'file.ts',
+          created_at: String(createdAt),
+        },
+        body: { user_id: '1234', content_id: '4321' },
+      },
+    ]
+
+    await pubSubClient.publishEventsInBatch(events)
+
+    expect(publishMessageSpy).toHaveBeenCalledTimes(2)
+    expect(publishMessageSpy).toHaveBeenNthCalledWith(1, {
+      attributes: {
+        action: PubSubActionEnum.sent,
+        created_at: String(createdAt),
+        source: 'file.ts',
+        type: 'io.skore.events.messaging.conversation',
+      },
+      data: expect.any(Buffer),
+    })
+  }
+
+  @test
+  async '[publishEventsInBatch] Given an array with more than 1000 items, then throw error'() {
+    const pubSubClient = new PubSubClient()
+
+    const mockArray = []
+    mockArray.length = 1001
+
+    await expect(pubSubClient.publishEventsInBatch(mockArray)).rejects.toThrow(
+      'fail to publish event',
+    )
+  }
+
+  @test
   async 'Should throw ValidationAttributeError at validate attributes'() {
     const getClient = {}
 
@@ -127,9 +189,7 @@ export class GetClientTest {
 
     let err = null
     try {
-      /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-      // @ts-ignore
-      await pubSubClient.validate(attributePubSubDtoFake)
+      await pubSubClient.validate(attributePubSubDtoFake as never)
     } catch (error) {
       err = error
     }
@@ -144,8 +204,8 @@ export class GetClientTest {
     })
   }
 
-  @test()
-  async 'Should throw ValidationAttributeError at validate attributes empty '() {
+  @test
+  async '[validate] Should throw ValidationAttributeError at validate attributes empty '() {
     const getClient = {}
 
     const pubSubClient = new PubSubClient({ getClient })
@@ -157,9 +217,7 @@ export class GetClientTest {
 
     let err = null
     try {
-      /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-      // @ts-ignore
-      await pubSubClient.validate(attributePubSubDtoFake)
+      await pubSubClient.validate(attributePubSubDtoFake as never)
     } catch (error) {
       err = error
     }
@@ -171,8 +229,8 @@ export class GetClientTest {
     })
   }
 
-  @test()
-  async 'Should throw internal error '() {
+  @test
+  async '[validate] Should throw internal error '() {
     const errorFake = new Error('yolo')
     jest.spyOn(validator, 'validateOrReject').mockRejectedValue(errorFake)
 
@@ -187,9 +245,7 @@ export class GetClientTest {
 
     let err = null
     try {
-      /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-      // @ts-ignore
-      await pubSubClient.validate(attributePubSubDtoFake)
+      await pubSubClient.validate(attributePubSubDtoFake as never)
     } catch (error) {
       err = error
     }


### PR DESCRIPTION
![gif-or-image](https://media.giphy.com/media/l0IybQ6l8nfKjxQv6/giphy-downsized.gif)

### What?

Adicionando método que publica mensagens em batch no PubSub.

### Why?

Estamos criando um enviador de eventos em batch para ser usado pelo nosso time interno.

### Any?

Existe um método semelhante que envia vários eventos do mesmo contexto. Os atributos não mudam, apenas o body. Marquei ele como depreciado e removi das docs para que ninguém mais o use. O ideal é usarmos o método `publishInBatch` a partir de agora.