### PR TITLE
feat(event): add enum canceled

### DIFF
--- a/packages/event/src/enum/pub-sub.enum.ts
+++ b/packages/event/src/enum/pub-sub.enum.ts
@@ -56,4 +56,5 @@ export enum PubSubActionEnum {
   send_max_seats_email = 'send_max_seats_email',
   leader_added = 'leader_added',
   leader_removed = 'leader_removed',
+  canceled = 'canceled',
 }


### PR DESCRIPTION
![gif-or-image](https://media.tenor.com/SLpmzEWgh-cAAAAM/pixelcraftian-minecraft.gif)

### What?
Adicionar enum `canceled` para utilizar no evento de cancelamento de um convite.

### Why?
Devemos implementar um enum que represente a ação de um cancelamento de convite.

### Task: ![asana-icon](https://i.imgur.com/mIiCCQu.png) [card_title](card_url/f)

<!-- Add task card link -->
