### PR TITLE
feat: different method to send to topic

### DIFF
--- a/packages/event/src/service/event.service.ts
+++ b/packages/event/src/service/event.service.ts
@@ -31,6 +31,8 @@ export class EventService {
   }
 
   async sendToTopic(attributes: EventAttributeDto, body: object, url: string): Promise<void> {
+    if (!url) throw new Error('Topic url is required')
+
     await this.client.publish(attributes, body, url)
   }
 

--- a/packages/event/src/service/event.service.ts
+++ b/packages/event/src/service/event.service.ts
@@ -30,6 +30,10 @@ export class EventService {
     await this.client.publish(attributes, body, eventUrl)
   }
 
+  async sendToTopic(attributes: EventAttributeDto, body: object, url: string): Promise<void> {
+    await this.client.publish(attributes, body, url)
+  }
+
   /**
    * @deprecated Use {@link publishInBatch} instead.
    */


### PR DESCRIPTION
![your incredible giphy](https://media.giphy.com/media/8eWq3hG0Q2fouhaItY/giphy.gif)

### What?

- Adiciona um método específico para enviar para um tópico diferente;

### Why?

Pois podemos causar problemas de loop infinito caso falte a url, utilizando o método anterior. Pois sempre cairia no tópico de eventos, e com os novos triggers do mongo, isso pode gerar um loop infinito;
