### PR TITLE
fix(schema): write interfaces to dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 A collection of NestJS extensions used by Learning.rocks.
 </p>
 
-| Name                                     | Description                                                      |
-| ---------------------------------------- | -----------------------------------------------------------------|
-| [`Auth`](./packages/auth)                | Authenticate and provide access to users, services and companies |
-| [`Bull`](./packages/bull)                | Setup bull queues along with bull-board                          |
-| [`Event`](./packages/event)              | Publish events to a topic in Pub/Sub                             |
-| [`Pagination`](./packages/pagination)    | Paginate graphql queries                                         |
+| Name                                  | Description                                                      |
+| ------------------------------------- | ---------------------------------------------------------------- |
+| [`Auth`](./packages/auth)             | Authenticate and provide access to users, services and companies |
+| [`Bull`](./packages/bull)             | Setup bull queues along with bull-board                          |
+| [`Event`](./packages/event)           | Publish events to a topic in Pub/Sub                             |
+| [`Schema`](./packages/schema)         | Generate and validate Typescript interfaces from json schemas    |
+| [`Pagination`](./packages/pagination) | Paginate graphql queries                                         |
 
 **Local Development**
 

--- a/packages/schema/src/script/copy-to-dist.script.ts
+++ b/packages/schema/src/script/copy-to-dist.script.ts
@@ -1,14 +1,25 @@
+/* eslint-disable no-console */
 import * as fs from 'fs'
 import * as path from 'path'
 
 const sourceDirectory = 'src/interface'
 const destinationDirectory = 'dist/src/interface'
 
-// Copy .d.ts files
-const files = fs.readdirSync(sourceDirectory).filter((file) => file.endsWith('.d.ts'))
+const directories = fs
+  .readdirSync(sourceDirectory)
+  .map((dir) => path.join(sourceDirectory, dir))
+  .filter((dir) => fs.statSync(dir).isDirectory())
 
-files.forEach((file) => {
-  const sourcePath = path.join(sourceDirectory, file)
-  const destinationPath = path.join(destinationDirectory, file)
-  fs.copyFileSync(sourcePath, destinationPath)
-})
+for (const directory of directories) {
+  console.info(`Copying files from directory=${directory} to dist`)
+
+  // Copy .d.ts files
+  const files = fs.readdirSync(directory).filter((file) => file.endsWith('.d.ts'))
+
+  files.forEach((file) => {
+    const sourcePath = path.join(directory, file)
+    const destinationPath = path.join(`${destinationDirectory}/${directory.split('/').pop()}`, file)
+
+    fs.copyFileSync(sourcePath, destinationPath)
+  })
+}


### PR DESCRIPTION
![your incredible giphy](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjdoZGpiZjR4YnowNzMwZnJpaW0xa3ZicnZ1bWNwa2FheHUzaW84OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EECy1Cp6nyV9e/giphy.gif)

### What?

Copiando todas as pastas de interfaces para o `/dist`.

### Why?

As interfaces não estavam sendo copiadas para o `/dist`.
Quebrei isso no PR: https://github.com/skore-io/nestjs-extensions/pull/149