### PR TITLE
feat: add publish retry

### DIFF
--- a/packages/event/src/client/pub-sub.client.ts
+++ b/packages/event/src/client/pub-sub.client.ts
@@ -75,10 +75,14 @@ export class PubSubClient implements EventClientInterface {
             ],
           },
         })
+
         return
       } catch (error) {
         retries++
         if (retries >= this.MAX_RETRIES) {
+          // eslint-disable-next-line no-console
+          console.error(`Error to publish event: ${error}`)
+
           throw new PublishPubSubError(error)
         }
 


### PR DESCRIPTION
![your incredible giphy](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXVoMnU1ZTAwcGI0bzRxNzY3b2llN25qamVsYmQ4aGsyZWpmMDYxZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KSCYjxdjm0yA0/giphy.gif)

### What?

- Adiciona retry para o envio do evento ao Pub/Sub;

### Why?

Pegamos alguns casos em que a chamada ao Pub/Sub simplesmente falha. Dessa forma, pensamos em adicionar um retry a nível de código caso aconteça algum erro;
