### PR TITLE
feat(pub_sub_type_event): add enum game audience

### DIFF
--- a/packages/event/src/enum/pub-sub.enum.ts
+++ b/packages/event/src/enum/pub-sub.enum.ts
@@ -31,6 +31,7 @@ export enum PubSubTypeEventEnum {
   'br.com.edtech.scormplay.events.content' = 'br.com.edtech.scormplay.events.content',
   'io.skore.events.content.import' = 'io.skore.events.content.import',
   'io.skore.events.mission.import' = 'io.skore.events.mission.import',
+  'io.skore.events.game.audience' = 'io.skore.events.game.audience',
 }
 
 export enum PubSubActionEnum {


### PR DESCRIPTION
![your incredible giphy](https://i.pinimg.com/originals/d1/f8/06/d1f80665564122d4a25526ecf6fe237a.gif)

### What?

- Adicionar enum para eventos da audiência do game `io.skore.events.game.audience`

### Why?

Para utilizar na criação de logs no mongo.

---


