### PR TITLE
fix(lerna): release version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,28 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Run lerna version
-        run: git update-index --assume-unchanged package-lock.json && lerna version --yes --conventional-commits
+      - name: Generate release
+        run: |
+          # Run lerna version and capture the output
+          output=$(npx lerna version --no-git-tag-version --yes 2>&1) # O '2>&1' redireciona stderr para stdout
+
+          # Extract first package change using grep and awk
+          read packageName oldVersion newVersion < <(echo "$output" | grep ' - ' | awk -F ': ' '{
+            split($1, packageInfo, " - ");
+            split($2, versionInfo, " => ");
+            print packageInfo[2], versionInfo[1], versionInfo[2];
+            exit; # Sair após a primeira linha processada
+          }')
+
+          # Check if any package has been modified and set the commit message
+          if [ -z "$packageName" ]; then
+            commitMessage="chore(release): new release published"
+          else
+            commitMessage="chore($packageName): $newVersion"
+          fi
+
+          # Execute the npm version script with the dynamic commit message
+          npm run version --message="$commitMessage"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,6 @@
       "createRelease": "github"
     },
     "version": {
-      "message": "chore(release): %s",
       "allowBranch": [
         "main"
       ],

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   ],
   "scripts": {
     "build": "lerna run build",
+    "ignore-package-lock": "git update-index --assume-unchanged package-lock.json",
     "lint": "eslint --ext .js,.ts,.json ./",
     "prepare": "husky install",
-    "publish": "git update-index --assume-unchanged package-lock.json && lerna publish --yes",
-    "test": "lerna run test --parallel"
+    "publish": "npm run ignore-package-lock && lerna publish --yes",
+    "test": "lerna run test --parallel",
+    "version": "npm run ignore-package-lock && lerna version --yes --message \"$npm_config_message\""
   },
   "dependencies": {
     "@nestjs/apollo": "^12.1.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -2,10 +2,6 @@
   "name": "@skore-io/auth",
   "version": "1.19.4",
   "description": "Package to authenticate users, companies and services",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com:skore-io/nestjs-extensions.git"
-  },
   "license": "UNLICENSED",
   "author": "Learning Rocks",
   "main": "dist/index.js",


### PR DESCRIPTION
![image](https://github.com/skore-io/nestjs-extensions/assets/19170390/0166ddd9-d766-442a-8ae0-c46998ca1ec4)

### What?

Ajustando o commit da release para seguir o formato: `chore(package_name): package_version`, usando o nome do pacote que foi atualizado e a nova versão.

Exemplo: `chore(@skore-io/auth): 1.19.12`

### Why?

Estavamos gerando um commit sem informações após release, conforme imagem do print.